### PR TITLE
Bump to 0.21.11, fix HTTP workspace routing, add Ed25519 signed calls

### DIFF
--- a/javascript/package.json
+++ b/javascript/package.json
@@ -1,6 +1,6 @@
 {
   "name": "hypha-rpc",
-  "version": "0.21.10",
+  "version": "0.21.11",
   "description": "Hypha RPC client for connecting to Hypha server for data management and AI model serving.",
   "main": "index.js",
   "module": "index.mjs",

--- a/javascript/src/crypto.js
+++ b/javascript/src/crypto.js
@@ -1,0 +1,141 @@
+/**
+ * Cryptographic utilities for hypha-rpc signed and encrypted service calls.
+ *
+ * Uses the Web Crypto API (native in browser and Node.js 20+) for Ed25519
+ * signing/verification. All output is interoperable with the Python
+ * `cryptography` package.
+ *
+ * @module crypto
+ */
+
+import { encode as msgpack_packb } from "@msgpack/msgpack";
+
+/**
+ * Get the SubtleCrypto instance, works in both browser and Node.js.
+ * @returns {SubtleCrypto}
+ */
+function getSubtle() {
+  if (typeof globalThis !== "undefined" && globalThis.crypto && globalThis.crypto.subtle) {
+    return globalThis.crypto.subtle;
+  }
+  throw new Error(
+    "Web Crypto API (crypto.subtle) is not available in this environment. " +
+    "Ed25519 signing requires a modern browser or Node.js 20+."
+  );
+}
+
+/**
+ * Generate an Ed25519 signing keypair.
+ * @returns {Promise<{privateKey: Uint8Array, publicKey: Uint8Array}>}
+ *   Raw 32-byte private key and 32-byte public key.
+ */
+export async function generateSigningKeypair() {
+  const subtle = getSubtle();
+  const keyPair = await subtle.generateKey("Ed25519", true, ["sign", "verify"]);
+
+  // Export raw keys
+  const publicRaw = new Uint8Array(
+    await subtle.exportKey("raw", keyPair.publicKey)
+  );
+
+  // Ed25519 private keys must be exported as PKCS8, then we extract the raw 32 bytes.
+  // PKCS8 for Ed25519 has a fixed 16-byte prefix, with the raw key at bytes 16-48.
+  const pkcs8 = new Uint8Array(
+    await subtle.exportKey("pkcs8", keyPair.privateKey)
+  );
+  const privateRaw = pkcs8.slice(16, 48);
+
+  return { privateKey: privateRaw, publicKey: publicRaw };
+}
+
+/**
+ * Import a raw 32-byte Ed25519 private key for signing.
+ * @param {Uint8Array} privateKeyBytes - 32-byte raw private key.
+ * @returns {Promise<CryptoKey>}
+ */
+async function importPrivateKey(privateKeyBytes) {
+  const subtle = getSubtle();
+  // Build PKCS8 wrapper: fixed 16-byte prefix for Ed25519 + 32-byte raw key
+  const pkcs8Prefix = new Uint8Array([
+    0x30, 0x2e, 0x02, 0x01, 0x00, 0x30, 0x05, 0x06,
+    0x03, 0x2b, 0x65, 0x70, 0x04, 0x22, 0x04, 0x20,
+  ]);
+  const pkcs8 = new Uint8Array(48);
+  pkcs8.set(pkcs8Prefix);
+  pkcs8.set(privateKeyBytes, 16);
+  return subtle.importKey("pkcs8", pkcs8, "Ed25519", false, ["sign"]);
+}
+
+/**
+ * Import a raw 32-byte Ed25519 public key for verification.
+ * @param {Uint8Array} publicKeyBytes - 32-byte raw public key.
+ * @returns {Promise<CryptoKey>}
+ */
+async function importPublicKey(publicKeyBytes) {
+  const subtle = getSubtle();
+  return subtle.importKey("raw", publicKeyBytes, "Ed25519", false, ["verify"]);
+}
+
+/**
+ * Sign data with an Ed25519 private key.
+ * @param {Uint8Array} privateKeyBytes - 32-byte raw Ed25519 private key.
+ * @param {Uint8Array} data - Data to sign.
+ * @returns {Promise<Uint8Array>} 64-byte Ed25519 signature.
+ */
+export async function signMessage(privateKeyBytes, data) {
+  const subtle = getSubtle();
+  const key = await importPrivateKey(privateKeyBytes);
+  const signature = await subtle.sign("Ed25519", key, data);
+  return new Uint8Array(signature);
+}
+
+/**
+ * Verify an Ed25519 signature.
+ * @param {Uint8Array} publicKeyBytes - 32-byte raw Ed25519 public key.
+ * @param {Uint8Array} signature - 64-byte Ed25519 signature.
+ * @param {Uint8Array} data - Data that was signed.
+ * @returns {Promise<boolean>} True if valid.
+ */
+export async function verifySignature(publicKeyBytes, signature, data) {
+  const subtle = getSubtle();
+  try {
+    const key = await importPublicKey(publicKeyBytes);
+    return await subtle.verify("Ed25519", key, signature, data);
+  } catch {
+    return false;
+  }
+}
+
+/**
+ * Create the canonical byte representation of a message for signing.
+ *
+ * Extracts signing-relevant fields from segment 1 and serializes them
+ * with msgpack for deterministic byte output (matching Python's implementation).
+ *
+ * @param {Object} mainMessage - The RPC message metadata.
+ * @returns {Uint8Array} Msgpack-encoded signable fields.
+ */
+export function createSignableData(mainMessage) {
+  // Use sorted keys for deterministic output matching Python's msgpack
+  const signable = {
+    _ts: mainMessage._ts,
+    from: mainMessage.from,
+    method: mainMessage.method,
+    to: mainMessage.to,
+    type: mainMessage.type,
+  };
+  return msgpack_packb(signable, { sortKeys: true });
+}
+
+/**
+ * Check if a timestamp is within acceptable bounds.
+ * @param {number} timestampMs - Timestamp in milliseconds.
+ * @param {number} [maxAgeSeconds=300] - Maximum age in seconds.
+ * @returns {boolean} True if the timestamp is within bounds.
+ */
+export function isTimestampValid(timestampMs, maxAgeSeconds = 300) {
+  const nowMs = Date.now();
+  const ageMs = nowMs - timestampMs;
+  // Allow 5 seconds of clock skew into the future
+  return -5000 <= ageMs && ageMs <= maxAgeSeconds * 1000;
+}

--- a/javascript/src/websocket-client.js
+++ b/javascript/src/websocket-client.js
@@ -28,6 +28,13 @@ export {
 export { RPC, API_VERSION, schemaFunction };
 export { loadRequirements };
 export { getRTCService, registerRTCService };
+export {
+  generateSigningKeypair,
+  signMessage,
+  verifySignature,
+  createSignableData,
+  isTimestampValid,
+} from "./crypto.js";
 
 const MAX_RETRY = 1000000;
 
@@ -753,6 +760,9 @@ export async function connectToServer(config) {
     app_id: config.app_id,
     server_base_url: connection_info.public_base_url,
     long_message_chunk_size: config.long_message_chunk_size,
+    signing: config.signing || false,
+    signing_private_key: config.signing_private_key || null,
+    signing_public_key: config.signing_public_key || null,
   });
   await rpc.waitFor("services_registered", config.method_timeout || 120);
   const wm = await rpc.get_manager_service({

--- a/python/hypha_rpc/crypto.py
+++ b/python/hypha_rpc/crypto.py
@@ -1,0 +1,134 @@
+"""Cryptographic utilities for hypha-rpc signed and encrypted service calls.
+
+This module provides Ed25519 signing/verification and (future) X25519 + AES-256-GCM
+encryption, using the `cryptography` package. All functions are designed to produce
+output that is interoperable with the Web Crypto API in JavaScript.
+
+The `cryptography` package is an optional dependency. If it is not installed,
+importing this module will raise ImportError at call time, not import time,
+so that the rest of hypha-rpc continues to work without it.
+"""
+
+import logging
+import time
+
+logger = logging.getLogger("hypha-rpc")
+
+try:
+    from cryptography.hazmat.primitives.asymmetric.ed25519 import (
+        Ed25519PrivateKey,
+        Ed25519PublicKey,
+    )
+    from cryptography.hazmat.primitives.serialization import (
+        Encoding,
+        PublicFormat,
+        PrivateFormat,
+        NoEncryption,
+    )
+
+    HAS_CRYPTO = True
+except ImportError:
+    HAS_CRYPTO = False
+
+
+def _require_crypto():
+    if not HAS_CRYPTO:
+        raise ImportError(
+            "The 'cryptography' package is required for signing/encryption. "
+            "Install it with: pip install cryptography"
+        )
+
+
+def generate_signing_keypair():
+    """Generate an Ed25519 signing keypair.
+
+    Returns:
+        tuple: (private_key_bytes, public_key_bytes) as raw 32-byte values.
+    """
+    _require_crypto()
+    private_key = Ed25519PrivateKey.generate()
+    private_bytes = private_key.private_bytes(
+        Encoding.Raw, PrivateFormat.Raw, NoEncryption()
+    )
+    public_bytes = private_key.public_key().public_bytes(
+        Encoding.Raw, PublicFormat.Raw
+    )
+    return private_bytes, public_bytes
+
+
+def sign_message(private_key_bytes, data):
+    """Sign data with an Ed25519 private key.
+
+    Args:
+        private_key_bytes: 32-byte raw Ed25519 private key.
+        data: bytes to sign.
+
+    Returns:
+        bytes: 64-byte Ed25519 signature.
+    """
+    _require_crypto()
+    private_key = Ed25519PrivateKey.from_private_bytes(private_key_bytes)
+    return private_key.sign(data)
+
+
+def verify_signature(public_key_bytes, signature, data):
+    """Verify an Ed25519 signature.
+
+    Args:
+        public_key_bytes: 32-byte raw Ed25519 public key.
+        signature: 64-byte Ed25519 signature.
+        data: bytes that were signed.
+
+    Returns:
+        bool: True if signature is valid, False otherwise.
+    """
+    _require_crypto()
+    try:
+        public_key = Ed25519PublicKey.from_public_bytes(public_key_bytes)
+        public_key.verify(signature, data)
+        return True
+    except Exception:
+        return False
+
+
+def create_signable_data(main_message):
+    """Create the canonical byte representation of a message for signing.
+
+    Extracts the signing-relevant fields from segment 1 and serializes them
+    with msgpack for deterministic byte output.
+
+    Args:
+        main_message: dict containing the RPC message metadata.
+
+    Returns:
+        bytes: msgpack-encoded signable fields.
+    """
+    import msgpack
+
+    # Use sorted keys for deterministic output across Python and JS
+    signable = {
+        "_ts": main_message.get("_ts"),
+        "from": main_message.get("from"),
+        "method": main_message.get("method"),
+        "to": main_message.get("to"),
+        "type": main_message.get("type"),
+    }
+    return msgpack.packb(signable, use_bin_type=True)
+
+
+def is_timestamp_valid(timestamp_ms, max_age_seconds=None):
+    """Check if a timestamp is within acceptable bounds.
+
+    Args:
+        timestamp_ms: Timestamp in milliseconds.
+        max_age_seconds: Maximum age in seconds. Defaults to 300 (5 minutes).
+
+    Returns:
+        bool: True if the timestamp is within bounds.
+    """
+    if max_age_seconds is None:
+        max_age_seconds = 300
+    now_ms = int(time.time() * 1000)
+    age_ms = now_ms - timestamp_ms
+    # Allow 5 seconds of clock skew into the future
+    return -5000 <= age_ms <= max_age_seconds * 1000

--- a/python/hypha_rpc/websocket_client.py
+++ b/python/hypha_rpc/websocket_client.py
@@ -914,6 +914,9 @@ async def _connect_to_server(config):
         app_id=config.get("app_id"),
         server_base_url=connection_info.get("public_base_url"),
         long_message_chunk_size=config.get("long_message_chunk_size"),
+        signing=config.get("signing", False),
+        signing_private_key=config.get("signing_private_key"),
+        signing_public_key=config.get("signing_public_key"),
     )
     await rpc.wait_for("services_registered", timeout=config.get("method_timeout", 120))
     wm = await rpc.get_manager_service(

--- a/python/pyproject.toml
+++ b/python/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "hypha_rpc"
-version = "0.21.10"
+version = "0.21.11"
 description = "Hypha RPC client for connecting to Hypha server for data management and AI model serving"
 readme = "README.md"
 requires-python = ">=3.9"


### PR DESCRIPTION
## Summary
- **Fix HTTP workspace routing bug**: HTTP transport was connecting to `public` workspace instead of the user's workspace when authenticated with a token. Now auto-extracts workspace from JWT token's `wid:` scope entry. Removed hardcoded `"public"` fallback from post-connection methods.
- **Add Ed25519 signed service calls (Phase 1)**: Services can declare `signing: true` to require cryptographic signatures on all calls. Supports both Python (`cryptography` package) and JavaScript (Web Crypto API). Signatures are interoperable across languages.
- **Bump version**: 0.21.10 → 0.21.11

## Test plan
- [x] Python HTTP workspace-from-token tests (integration + unit)
- [x] JavaScript HTTP workspace-from-token test
- [x] Python Ed25519 signing tests (cross-language interop, unauthorized rejection, replay protection)
- [x] JavaScript Ed25519 signing tests (same coverage)
- [x] All existing tests pass (168 Python, 73 JavaScript)

🤖 Generated with [Claude Code](https://claude.ai/code)