### PR TITLE
Expose Python connect_to_server silent option

### DIFF
--- a/python/hypha_rpc/websocket_client.py
+++ b/python/hypha_rpc/websocket_client.py
@@ -908,6 +908,7 @@ async def _connect_to_server(config):
         client_id=client_id,
         workspace=workspace,
         default_context={"connection_type": "websocket"},
+        silent=config.get("silent", False),
         name=config.get("name"),
         method_timeout=config.get("method_timeout"),
         loop=config.get("loop"),
@@ -1296,6 +1297,7 @@ def connect_to_server(config=None, **kwargs):
         client_id: Unique client identifier (optional, auto-generated if not provided)
         transport: Transport type - "websocket" (default) or "http"
         method_timeout: Timeout for RPC method calls
+        silent: Disable automatic service reporting on connect (optional)
         ssl: SSL configuration (True/False/SSLContext)
 
     Returns:


### PR DESCRIPTION
## Summary
- pass  from websocket client config into 
- document  in Python  configuration options

## Why
Incident mitigation sometimes requires connecting without automatic service reporting. The JavaScript and lower-level RPC paths already have silent semantics; this exposes a clean Python entry-point.

## Scope
- Python websocket client only
- backwards compatible default ()