### PR TITLE
followup: revert CI deps to released hypha 0.21.51

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -140,7 +140,7 @@ jobs:
         uses: actions/setup-python@v4.5.0
         with:
           python-version: "3.11"
-      - run: pip install "psutil" "redis==5.2.0" "hypha @ git+https://github.com/amun-ai/hypha@main" "aioboto3==13.1.1" "dulwich>=0.21.7"
+      - run: pip install "psutil" "redis==5.2.0" "hypha>=0.21.51" "aioboto3==13.1.1" "dulwich>=0.21.7"
       - run: npm run test
       - run: npm run build
       - name: Publish package on NPM

--- a/.github/workflows/test-js.yml
+++ b/.github/workflows/test-js.yml
@@ -44,7 +44,7 @@ jobs:
         uses: actions/setup-python@v4.5.0
         with:
           python-version: "3.11"
-      - run: pip install "psutil" "redis==5.2.0" "hypha @ git+https://github.com/amun-ai/hypha@main" "aioboto3==13.1.1" "dulwich>=0.21.7"
+      - run: pip install "psutil" "redis==5.2.0" "hypha>=0.21.51" "aioboto3==13.1.1" "dulwich>=0.21.7"
       - run: npm run test
       - name: Upload coverage reports
         uses: actions/upload-artifact@v4.4.3

--- a/python/pyproject.toml
+++ b/python/pyproject.toml
@@ -16,7 +16,7 @@ email = "oeway007@gmail.com"
 [project.optional-dependencies]
 encryption = [ "PyNaCl>=1.5.0",]
 full = [ "aiortc; platform_system != 'Emscripten'", "zarr", "fastapi", "sse-starlette", "openai", "simpervisor", "fastmcp>=2.10.6", "mcp>=1.12.0", "PyNaCl>=1.5.0",]
-test = [ "pytest>=7.2.1", "pytest-cov>=4.0.0", "pytest-timeout>=2.1.0", "pytest-asyncio>=0.20.3", "aioboto3>=13.1.1", "jupyter>=1.0.0", "jupyter_client>=8.3.0", "redis>=5.2.0", "hypha @ git+https://github.com/amun-ai/hypha@main", "sse-starlette>=2.1.3", "simpervisor>=1.0.0", "uvicorn[standard]>=0.31.1", "aiortc>=1.9.0; platform_system != 'Emscripten'", "openai>=1.92.2", "fastmcp==2.11.2", "mcp==1.19.0", "PyNaCl>=1.5.0",]
+test = [ "pytest>=7.2.1", "pytest-cov>=4.0.0", "pytest-timeout>=2.1.0", "pytest-asyncio>=0.20.3", "aioboto3>=13.1.1", "jupyter>=1.0.0", "jupyter_client>=8.3.0", "redis>=5.2.0", "hypha>=0.21.51", "sse-starlette>=2.1.3", "simpervisor>=1.0.0", "uvicorn[standard]>=0.31.1", "aiortc>=1.9.0; platform_system != 'Emscripten'", "openai>=1.92.2", "fastmcp==2.11.2", "mcp==1.19.0", "PyNaCl>=1.5.0",]
 
 [tool.setuptools]
 include-package-data = true

--- a/python/requirements_test.txt
+++ b/python/requirements_test.txt
@@ -6,7 +6,7 @@ aioboto3==13.1.1
 jupyter==1.0.0
 jupyter_client==8.3.0
 redis==5.2.0
-hypha @ git+https://github.com/amun-ai/hypha@main
+hypha==0.21.51
 sse-starlette==2.1.3
 simpervisor==1.0.0
 uvicorn[standard]==0.31.1


### PR DESCRIPTION
## Summary
- Revert Python test deps from git branch install back to `hypha==0.21.51`
- Revert JS test workflow from git branch install back to `hypha>=0.21.51`

## Prerequisites
- [ ] hypha 0.21.51 published to PyPI (merge + release #864 first)

## Test plan
- [ ] CI passes with hypha 0.21.51 from PyPI

🤖 Generated with [Claude Code](https://claude.com/claude-code)