### PR TITLE
fix: preserve local methods on wm proxy after reconnection

### DIFF
--- a/javascript/src/http-client.js
+++ b/javascript/src/http-client.js
@@ -730,25 +730,25 @@ export async function _connectToServerHTTP(config) {
   // Auto-refresh workspace manager proxy after reconnection.
   // See websocket-client.js for detailed explanation.
   let isInitialRefresh = true;
-  rpc.on("manager_refreshed", async ({ manager: internalManager }) => {
+  rpc.on("manager_refreshed", async () => {
     if (isInitialRefresh) {
       isInitialRefresh = false;
       return;
     }
     try {
-      const freshWm = internalManager;
-      for (const key of Object.keys(freshWm)) {
-        if (typeof freshWm[key] === "function") {
-          wm[key] = freshWm[key];
+      const newTarget = `*/${rpc._connection.manager_id}`;
+      for (const key of Object.keys(wm)) {
+        if (typeof wm[key] === "function" && wm[key].__rpc_object__) {
+          wm[key].__rpc_object__._rtarget = newTarget;
         }
       }
       console.info(
-        "Workspace manager proxy refreshed after reconnection (new manager_id:",
+        "Workspace manager proxy retargeted after reconnection (new manager_id:",
         rpc._connection?.manager_id + ")",
       );
     } catch (err) {
       console.warn(
-        "Failed to refresh workspace manager after reconnection:",
+        "Failed to retarget workspace manager after reconnection:",
         err,
       );
     }

--- a/javascript/src/rpc.js
+++ b/javascript/src/rpc.js
@@ -2325,6 +2325,10 @@ export class RPC extends MessageEmitter {
     function remote_method() {
       return new Promise(async (resolve, reject) => {
         try {
+          // Read target_id from encoded_method at call time (not captured
+          // at generation time) so that _rtarget can be updated after
+          // reconnection without regenerating the method closures.
+          const target_id = encoded_method._rtarget;
           let local_session_id = randId();
           if (local_parent) {
             // Store the children session under the parent

--- a/javascript/src/websocket-client.js
+++ b/javascript/src/websocket-client.js
@@ -838,50 +838,34 @@ export async function connectToServer(config) {
   wm.rpc = rpc;
 
   // Auto-refresh workspace manager proxy after reconnection.
-  // When the server restarts, it assigns a new manager_id. The wm proxy
-  // returned to the caller has methods bound to the old manager_id.
-  //
-  // The RPC layer fires "manager_refreshed" IMMEDIATELY after getting the
-  // fresh manager service — before service re-registration. This minimizes
-  // the window where stale methods exist (~100ms instead of ~2-3s).
-  //
-  // Combined with the RPC layer's immediate rejection of pending calls to
-  // the old manager_id, recovery is near-instant.
+  // When the server restarts, it assigns a new manager_id. The remote
+  // methods on wm have their target baked into __rpc_object__._rtarget.
+  // Since remote_method() reads _rtarget at call time (not generation
+  // time), we just update _rtarget on every existing method — no need
+  // to regenerate methods or copy from a fresh proxy. This preserves
+  // locally-overridden methods (registerService, unregisterService, etc.)
+  // that would otherwise be lost by wholesale function copying.
   let isInitialRefresh = true;
-  rpc.on("manager_refreshed", async ({ manager: internalManager }) => {
+  rpc.on("manager_refreshed", async () => {
     if (isInitialRefresh) {
       isInitialRefresh = false;
       return; // Skip the first event (initial connection, wm is already fresh)
     }
     try {
-      let freshWm;
-      if (config.kwargs_expansion) {
-        // kwargs_expansion changes the method signatures, so we need to
-        // fetch a new manager with matching config
-        freshWm = await rpc.get_manager_service({
-          timeout: config.method_timeout || 30,
-          case_conversion: "camel",
-          kwargs_expansion: config.kwargs_expansion,
-        });
-      } else {
-        // The internal manager already uses case_conversion: "camel",
-        // so we can copy directly without an extra RPC call
-        freshWm = internalManager;
-      }
-      // Copy all function properties from fresh wm onto existing wm object.
-      // This preserves the caller's reference while updating method targets.
-      for (const key of Object.keys(freshWm)) {
-        if (typeof freshWm[key] === "function") {
-          wm[key] = freshWm[key];
+      const newTarget = `*/${rpc._connection.manager_id}`;
+      // Retarget all remote methods on the wm proxy to the new manager
+      for (const key of Object.keys(wm)) {
+        if (typeof wm[key] === "function" && wm[key].__rpc_object__) {
+          wm[key].__rpc_object__._rtarget = newTarget;
         }
       }
       console.info(
-        "Workspace manager proxy refreshed after reconnection (new manager_id:",
+        "Workspace manager proxy retargeted after reconnection (new manager_id:",
         rpc._connection?.manager_id + ")",
       );
     } catch (err) {
       console.warn(
-        "Failed to refresh workspace manager after reconnection:",
+        "Failed to retarget workspace manager after reconnection:",
         err,
       );
     }


### PR DESCRIPTION
## Summary

- Fixes #144: `register_service` fails after WebSocket reconnection with "Service id info must contain ':'" error
- The `manager_refreshed` handler was copying ALL functions from the fresh remote manager proxy onto the `wm` object, overwriting locally-bound methods (`registerService`/`register_service`) with remote proxy counterparts
- Replaced "copy all functions" approach with "retarget `_rtarget`" approach: update the target ID on existing remote methods to point to the new manager, preserving locally-bound overrides
- **JS fix**: read `encoded_method._rtarget` at call time inside `remote_method()` instead of capturing it in a closure at generation time
- **Python fix**: refresh handler now iterates `wm`'s own methods and updates `_encoded_method["_rtarget"]`

## Test plan

- [x] Verified with real integration test: force-close WebSocket twice, register new service after reconnection
- [x] Test **fails** without fix (remote `register_service` sends raw dict → server assertion error)
- [x] Test **passes** with fix (local `register_service` preserved, proper ID construction)
- [x] Existing server tests pass (13/13)
- [ ] CI passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)